### PR TITLE
Update urllib3 to >=2.6.0 to address security vulnerabilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "litellm>=1.70.0",
     "httpcore>=1.0.7,<2",
     "google-genai>=1.16.0,<2",
+    "urllib3>=2.6.0",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1577,9 +1577,9 @@ typing-inspection==0.4.2 \
 tzdata==2025.2 \
     --hash=sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8 \
     --hash=sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9
-urllib3==2.5.0 \
-    --hash=sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760 \
-    --hash=sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc
+urllib3==2.6.2 \
+    --hash=sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797 \
+    --hash=sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd
 verspec==0.1.0 \
     --hash=sha256:741877d5633cc9464c45a469ae2a31e801e6dbbaa85b9675d481cda100f11c31 \
     --hash=sha256:c4504ca697b2056cdb4bfa7121461f5a0e81809255b41c03dda4ba823637c01e

--- a/uv.lock
+++ b/uv.lock
@@ -2308,6 +2308,7 @@ dependencies = [
     { name = "tabulate" },
     { name = "tenacity" },
     { name = "tqdm" },
+    { name = "urllib3" },
 ]
 
 [package.dev-dependencies]
@@ -2344,6 +2345,7 @@ requires-dist = [
     { name = "tabulate", specifier = ">=0.9.0,<0.10" },
     { name = "tenacity", specifier = ">=9.0.0,<10" },
     { name = "tqdm", specifier = ">=4.67.1,<5" },
+    { name = "urllib3", specifier = ">=2.6.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -2597,11 +2599,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.5.0"
+version = "2.6.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185 }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/24/a2a2ed9addd907787d7aa0355ba36a6cadf1768b934c652ea78acbd59dcd/urllib3-2.6.2.tar.gz", hash = "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797", size = 432930 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795 },
+    { url = "https://files.pythonhosted.org/packages/6d/b9/4095b668ea3678bf6a0af005527f39de12fb026516fb3df17495a733b7f8/urllib3-2.6.2-py3-none-any.whl", hash = "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd", size = 131182 },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR updates urllib3 from version 2.5.0 to 2.6.2 to address high-severity security vulnerabilities identified by Snyk:

## Vulnerabilities Fixed
1. **Improper Handling of Highly Compressed Data (Data Amplification)** - High severity
2. **Allocation of Resources Without Limits or Throttling** - High severity

## Changes
- Added urllib3>=2.6.0 as a direct dependency constraint in pyproject.toml
- Updated urllib3 from 2.5.0 to 2.6.2 in uv.lock
- Regenerated requirements.txt with updated urllib3 version

## Testing
- Lock file regenerated successfully
- All dependencies resolved correctly

Fixes security vulnerabilities identified by Snyk on Dec 9, 2025."